### PR TITLE
Testing pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ interested in making performance optimizations beneficial to workloads similar
 to Google's.
 This repository contains the Fleetbench C++ code.
 
-[TOC]
-
 ## Overview
 
 Fleetbench is a benchmarking suite that consists of a curated set of


### PR DESCRIPTION
Removed [TOC] in markdown, which is instead auto-generated by Github: https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/.